### PR TITLE
Fix layout issue on course page

### DIFF
--- a/app/(course)/course/[courseId]/layout.tsx
+++ b/app/(course)/course/[courseId]/layout.tsx
@@ -48,7 +48,7 @@ const CourseLayout = async ({
   const progressCount = getProgress(session?.user.id ?? '', course.id)
 
   return (
-    <div className="md:mt-20 max-w-7xl mx-auto">
+    <div className="md:mt-20 max-w-7xl mx-auto w-full">
       <CourseNavbar 
         course={course}
         progressCount={progressCount}


### PR DESCRIPTION
# Description

![image](https://github.com/user-attachments/assets/8961af8d-09cc-483a-8df7-ee05d9916ea9)

Currently the layout of the course page is not taking up the full width it can due to positioning using margins. I fixed this issue by applying a full width class (`w-full`) to the courses layout page.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] The code works fine on my machine.